### PR TITLE
Menus now follow an object that reports an Offset when requested, instead of always following a static Offset (Resolves #2)

### DIFF
--- a/example/lib/demos/demo_popover_menu.dart
+++ b/example/lib/demos/demo_popover_menu.dart
@@ -154,7 +154,7 @@ class _DraggableDemoState extends State<DraggableDemo> {
           child: GestureDetector(
             onPanUpdate: _onPanUpdate,
             child: CupertinoPopoverMenu(
-              globalFocalPoint: widget.focalPoint,
+              focalPoint: StationaryMenuFocalPoint(widget.focalPoint),
               padding: const EdgeInsets.all(12.0),
               arrowBaseWidth: 21,
               arrowLength: 20,
@@ -195,7 +195,7 @@ class PopoverExample extends StatelessWidget {
   Widget build(BuildContext context) {
     return Center(
       child: CupertinoPopoverMenu(
-        globalFocalPoint: focalPoint,
+        focalPoint: StationaryMenuFocalPoint(focalPoint),
         padding: const EdgeInsets.all(12.0),
         arrowBaseWidth: 21,
         arrowLength: 20,

--- a/example/lib/demos/demo_popover_menu_bouncing_ball.dart
+++ b/example/lib/demos/demo_popover_menu_bouncing_ball.dart
@@ -70,7 +70,7 @@ class _PopoverMenuBouncingBallDemoState extends State<PopoverMenuBouncingBallDem
 
   Widget _buildMenu() {
     return CupertinoPopoverMenu(
-      globalFocalPoint: _globalMenuFocalPoint,
+      focalPoint: StationaryMenuFocalPoint(_globalMenuFocalPoint),
       padding: const EdgeInsets.all(12.0),
       child: const SizedBox(
         width: _menuWidth,

--- a/example/lib/demos/demo_popover_menu_draggable_ball.dart
+++ b/example/lib/demos/demo_popover_menu_draggable_ball.dart
@@ -84,7 +84,7 @@ class _PopoverMenuDraggableBallDemoState extends State<PopoverMenuDraggableBallD
 
   Widget _buildMenu() {
     return CupertinoPopoverMenu(
-      globalFocalPoint: _globalMenuFocalPoint,
+      focalPoint: StationaryMenuFocalPoint(_globalMenuFocalPoint),
       padding: const EdgeInsets.all(12.0),
       child: const SizedBox(
         width: _menuWidth,

--- a/example/lib/demos/demo_toolbar.dart
+++ b/example/lib/demos/demo_toolbar.dart
@@ -208,7 +208,7 @@ class _DraggableDemoState extends State<DraggableDemo> {
           child: GestureDetector(
             onPanUpdate: _onPanUpdate,
             child: CupertinoPopoverToolbar(
-              globalFocalPoint: widget.focalPoint,
+              focalPoint: StationaryMenuFocalPoint(widget.focalPoint),
               padding: const EdgeInsets.all(12.0),
               arrowBaseWidth: 21,
               arrowLength: 20,
@@ -248,11 +248,11 @@ class ToolbarExample extends StatelessWidget {
   Widget build(BuildContext context) {
     final toolbar = children != null
         ? CupertinoPopoverToolbar(
-            globalFocalPoint: focalPoint,
+            focalPoint: StationaryMenuFocalPoint(focalPoint),
             children: children!,
           )
         : CupertinoPopoverToolbar.paginated(
-            globalFocalPoint: focalPoint,
+            focalPoint: StationaryMenuFocalPoint(focalPoint),
             pages: pages,
           );
 

--- a/example/lib/demos/demo_toolbar_bouncing_ball.dart
+++ b/example/lib/demos/demo_toolbar_bouncing_ball.dart
@@ -69,7 +69,7 @@ class _ToolbarBouncingBallDemoState extends State<ToolbarBouncingBallDemo> with 
 
   Widget _buildMenu() {
     return CupertinoPopoverToolbar(
-      globalFocalPoint: _globalMenuFocalPoint,
+      focalPoint: StationaryMenuFocalPoint(_globalMenuFocalPoint),
       children: const [
         CupertinoPopoverToolbarMenuItem(label: 'Style'),
         CupertinoPopoverToolbarMenuItem(label: 'Duplicate'),

--- a/example/lib/demos/demo_toolbar_draggable_ball.dart
+++ b/example/lib/demos/demo_toolbar_draggable_ball.dart
@@ -83,7 +83,7 @@ class _ToolbarDraggableBallDemoState extends State<ToolbarDraggableBallDemo> {
 
   Widget _buildMenu() {
     return CupertinoPopoverToolbar(
-      globalFocalPoint: _globalMenuFocalPoint,
+      focalPoint: StationaryMenuFocalPoint(_globalMenuFocalPoint),
       children: const [
         CupertinoPopoverToolbarMenuItem(label: 'Style'),
         CupertinoPopoverToolbarMenuItem(label: 'Duplicate'),

--- a/example/lib/demos/demo_toolbar_wide_draggable_ball.dart
+++ b/example/lib/demos/demo_toolbar_wide_draggable_ball.dart
@@ -83,7 +83,7 @@ class _WideToolbarDraggableBallDemoState extends State<WideToolbarDraggableBallD
 
   Widget _buildMenu() {
     return CupertinoPopoverToolbar(
-      globalFocalPoint: _globalMenuFocalPoint,
+      focalPoint: StationaryMenuFocalPoint(_globalMenuFocalPoint),
       children: const [
         CupertinoPopoverToolbarMenuItem(label: 'Style'),
         CupertinoPopoverToolbarMenuItem(label: 'Duplicate'),

--- a/example/lib/demos/inventory_demo.dart
+++ b/example/lib/demos/inventory_demo.dart
@@ -16,7 +16,7 @@ class _InventoryDemoState extends State<InventoryDemo> {
         Expanded(
           child: Center(
             child: CupertinoPopoverToolbar(
-              globalFocalPoint: Offset.zero,
+              focalPoint: const StationaryMenuFocalPoint(Offset.zero),
               children: _toolbarMenuItems,
             ),
           ),
@@ -24,7 +24,7 @@ class _InventoryDemoState extends State<InventoryDemo> {
         const Expanded(
           child: Center(
             child: CupertinoPopoverMenu(
-              globalFocalPoint: Offset.zero,
+              focalPoint: StationaryMenuFocalPoint(Offset.zero),
               padding: EdgeInsets.all(16),
               child: Text("Popover Menu"),
             ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,48 +5,42 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.10.0"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
   flutter:
@@ -58,8 +52,7 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   flutter_test:
@@ -71,57 +64,44 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: HEAD
-      resolved-ref: "0ecf92b46d52ad8fb9ef7928713c930b5df29f05"
+      ref: main
+      resolved-ref: a0259abdb7facdb8af875df36ff31752b6c075bc
       url: "git@github.com:Flutter-Bounty-Hunters/follow_the_leader.git"
     source: git
     version: "0.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.5"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   logging:
     dependency: transitive
     description:
       name: logging
-      sha256: c0bbfe94d46aedf9b8b3e695cf3bd48c8e14b35e3b2c639e0aa7755d589ba946
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
   overlord:
@@ -135,8 +115,7 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.2"
   sky_engine:
@@ -148,58 +127,51 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.11.0"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "862015c5db1f3f3c4ea3b94dc2490363a84262994b88902315ed74be1155612f"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: c9aba3b3dbfe8878845dfab5fa096eb8de7b62231baeeb1cea8e3ee81ca8c6d8
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.15"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.18.0 <4.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -19,6 +19,7 @@ dependency_overrides:
   follow_the_leader:
     git:
       url: git@github.com:Flutter-Bounty-Hunters/follow_the_leader.git
+      ref: main
 
 dev_dependencies:
   flutter_test:

--- a/lib/follow_the_leader.dart
+++ b/lib/follow_the_leader.dart
@@ -3,3 +3,4 @@ library overlord;
 // Exports tools to integrate Overlord popovers with the follow_the_leader package,
 // which makes it easy to position various popovers near their associated content.
 export 'src/cupertino/cupertino_popover_aligners.dart';
+export 'src/menus/menu_with_pointer_follower.dart';

--- a/lib/overlord.dart
+++ b/lib/overlord.dart
@@ -3,4 +3,6 @@ library overlord;
 export 'src/cupertino/cupertino_popover_menu.dart';
 export 'src/cupertino/cupertino_toolbar.dart';
 
+export 'src/menus/menu_with_pointer.dart';
+
 export 'src/logging.dart';

--- a/lib/src/cupertino/cupertino_popover_menu.dart
+++ b/lib/src/cupertino/cupertino_popover_menu.dart
@@ -224,6 +224,7 @@ class RenderPopover extends RenderShiftedBox {
   @override
   void paint(PaintingContext context, Offset offset) {
     final localFocalPoint = globalToLocal(focalPoint.globalOffset!);
+    print("Menu focal point: ${focalPoint.globalOffset!}");
 
     final contentOffset = _computeContentOffset(arrowLength);
     final direction = _computeArrowDirection(Offset.zero & size, localFocalPoint);

--- a/lib/src/cupertino/cupertino_popover_menu.dart
+++ b/lib/src/cupertino/cupertino_popover_menu.dart
@@ -2,15 +2,16 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:overlord/src/menus/menu_with_pointer.dart';
 
 /// An iOS-style popover menu.
 ///
 /// A [CupertinoPopoverMenu] displays content within a rounded rectangle shape,
-/// along with an arrow that points in the general direction of the [globalFocalPoint].
+/// along with an arrow that points in the general direction of the [focalPoint].
 class CupertinoPopoverMenu extends SingleChildRenderObjectWidget {
   const CupertinoPopoverMenu({
     super.key,
-    required this.globalFocalPoint,
+    required this.focalPoint,
     this.borderRadius = 12.0,
     this.arrowBaseWidth = 18.0,
     this.arrowLength = 12.0,
@@ -21,13 +22,8 @@ class CupertinoPopoverMenu extends SingleChildRenderObjectWidget {
     super.child,
   });
 
-  /// Global offset which the arrow should point to.
-  ///
-  /// If the arrow can't point to [globalFocalPoint], e.g.,
-  /// the arrow points up and `globalFocalPoint.dx` is outside
-  /// the menu bounds, then the the arrow will point towards
-  /// [globalFocalPoint] as much as possible.
-  final Offset globalFocalPoint;
+  /// Where the toolbar arrow should point.
+  final MenuFocalPoint focalPoint;
 
   /// Indicates whether or not the arrow can point to a horizontal direction.
   ///
@@ -70,7 +66,7 @@ class CupertinoPopoverMenu extends SingleChildRenderObjectWidget {
       padding: padding,
       screenSize: MediaQuery.of(context).size,
       backgroundColor: backgroundColor,
-      focalPoint: globalFocalPoint,
+      focalPoint: focalPoint,
       allowHorizontalArrow: allowHorizontalArrow,
       showDebugPaint: showDebugPaint,
     );
@@ -85,7 +81,7 @@ class CupertinoPopoverMenu extends SingleChildRenderObjectWidget {
       ..arrowLength = arrowLength
       ..padding = padding
       ..screenSize = MediaQuery.of(context).size
-      ..focalPoint = globalFocalPoint
+      ..focalPoint = focalPoint
       ..backgroundColor = backgroundColor
       ..allowHorizontalArrow = allowHorizontalArrow
       ..showDebugPaint = showDebugPaint;
@@ -98,7 +94,7 @@ class RenderPopover extends RenderShiftedBox {
     required double arrowWidth,
     required double arrowLength,
     required Color backgroundColor,
-    required Offset focalPoint,
+    required MenuFocalPoint focalPoint,
     required Size screenSize,
     bool allowHorizontalArrow = true,
     EdgeInsets? padding,
@@ -143,9 +139,9 @@ class RenderPopover extends RenderShiftedBox {
     }
   }
 
-  Offset _focalPoint;
-  Offset get focalPoint => _focalPoint;
-  set focalPoint(Offset value) {
+  MenuFocalPoint _focalPoint;
+  MenuFocalPoint get focalPoint => _focalPoint;
+  set focalPoint(MenuFocalPoint value) {
     if (_focalPoint != value) {
       _focalPoint = value;
       markNeedsLayout();
@@ -227,7 +223,7 @@ class RenderPopover extends RenderShiftedBox {
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    final localFocalPoint = globalToLocal(focalPoint);
+    final localFocalPoint = globalToLocal(focalPoint.globalOffset!);
 
     final contentOffset = _computeContentOffset(arrowLength);
     final direction = _computeArrowDirection(Offset.zero & size, localFocalPoint);

--- a/lib/src/cupertino/cupertino_toolbar.dart
+++ b/lib/src/cupertino/cupertino_toolbar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:overlord/src/menus/menu_with_pointer.dart';
 
 import 'cupertino_popover_menu.dart';
 
@@ -17,7 +18,7 @@ class CupertinoPopoverToolbar extends StatefulWidget {
   /// If all the items fit inside the available width, next page and previous page buttons aren't displayed.
   const CupertinoPopoverToolbar({
     Key? key,
-    required this.globalFocalPoint,
+    required this.focalPoint,
     this.arrowBaseWidth = 18.0,
     this.arrowLength = 12.0,
     this.height = 39.0,
@@ -31,7 +32,7 @@ class CupertinoPopoverToolbar extends StatefulWidget {
   /// Creates a toolbar which is paginated using [pages].
   const CupertinoPopoverToolbar.paginated({
     super.key,
-    required this.globalFocalPoint,
+    required this.focalPoint,
     this.arrowBaseWidth = 18.0,
     this.arrowLength = 12.0,
     this.height = 39.0,
@@ -41,13 +42,12 @@ class CupertinoPopoverToolbar extends StatefulWidget {
     required this.pages,
   }) : children = null;
 
-  /// Global offset which the arrow should point to.
+  /// Where the toolbar's arrow should point.
   ///
-  /// If the arrow can't point to [globalFocalPoint], e.g.,
-  /// the arrow points up and `globalFocalPoint.dx` is outside
-  /// the menu bounds, then the the arrow will point towards
-  /// [globalFocalPoint] as much as possible.
-  final Offset globalFocalPoint;
+  /// If the arrow can't point to [focalPoint], e.g., the arrow points up and
+  /// [focalPoint] is outside the menu bounds, then the the arrow will point towards
+  /// [focalPoint] as much as possible.
+  final MenuFocalPoint focalPoint;
 
   /// Base of the arrow in pixels.
   ///
@@ -105,7 +105,7 @@ class _CupertinoPopoverToolbarState extends State<CupertinoPopoverToolbar> {
       arrowBaseWidth: widget.arrowBaseWidth,
       arrowLength: widget.arrowLength,
       backgroundColor: widget.backgroundColor,
-      globalFocalPoint: widget.globalFocalPoint,
+      focalPoint: widget.focalPoint,
       allowHorizontalArrow: false,
       padding: widget.padding,
       child: _buildContent(),

--- a/lib/src/menu_with_pointer.dart
+++ b/lib/src/menu_with_pointer.dart
@@ -1,1 +1,0 @@
-// TODO: a rounded rectangle menu with an arrow that points towards a focal point

--- a/lib/src/menus/menu_with_pointer.dart
+++ b/lib/src/menus/menu_with_pointer.dart
@@ -1,0 +1,17 @@
+import 'dart:ui';
+
+/// A focal point for the arrow on a popover menu, such as an iOS-style
+/// popover toolbar, which points at the content it applies to.
+abstract class MenuFocalPoint {
+  Offset? get globalOffset;
+}
+
+/// A [MenuFocalPoint] that never changes.
+class StationaryMenuFocalPoint implements MenuFocalPoint {
+  const StationaryMenuFocalPoint(this.globalOffset);
+
+  @override
+  final Offset globalOffset;
+}
+
+// TODO: a rounded rectangle menu with an arrow that points towards a focal point

--- a/lib/src/menus/menu_with_pointer_follower.dart
+++ b/lib/src/menus/menu_with_pointer_follower.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:follow_the_leader/follow_the_leader.dart';
+import 'package:overlord/src/menus/menu_with_pointer.dart';
+
+class MenuWithPointerBuilder extends StatefulWidget {
+  const MenuWithPointerBuilder({
+    Key? key,
+    required this.builder,
+  }) : super(key: key);
+
+  final void Function(BuildContext, Offset focalPoint) builder;
+
+  @override
+  State<MenuWithPointerBuilder> createState() => _MenuWithPointerBuilderState();
+}
+
+class _MenuWithPointerBuilderState extends State<MenuWithPointerBuilder> {
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}
+
+/// A [MenuFocalPoint] that's calculated on demand, based on the bounding
+/// rectangle of a [Leader].
+class LeaderMenuFocalPoint implements MenuFocalPoint {
+  const LeaderMenuFocalPoint({
+    required LeaderLink link,
+    Alignment alignment = Alignment.center,
+  })  : _link = link,
+        _alignment = alignment;
+
+  final LeaderLink _link;
+  final Alignment _alignment;
+
+  @override
+  Offset? get globalOffset {
+    if (!_link.leaderConnected) {
+      return null;
+    }
+
+    final leaderRect = _link.leader!.offset & _link.leaderSize!;
+    return _alignment.withinRect(leaderRect);
+  }
+}

--- a/lib/src/menus/menu_with_pointer_follower.dart
+++ b/lib/src/menus/menu_with_pointer_follower.dart
@@ -2,25 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:follow_the_leader/follow_the_leader.dart';
 import 'package:overlord/src/menus/menu_with_pointer.dart';
 
-class MenuWithPointerBuilder extends StatefulWidget {
-  const MenuWithPointerBuilder({
-    Key? key,
-    required this.builder,
-  }) : super(key: key);
-
-  final void Function(BuildContext, Offset focalPoint) builder;
-
-  @override
-  State<MenuWithPointerBuilder> createState() => _MenuWithPointerBuilderState();
-}
-
-class _MenuWithPointerBuilderState extends State<MenuWithPointerBuilder> {
-  @override
-  Widget build(BuildContext context) {
-    return Container();
-  }
-}
-
 /// A [MenuFocalPoint] that's calculated on demand, based on the bounding
 /// rectangle of a [Leader].
 class LeaderMenuFocalPoint implements MenuFocalPoint {

--- a/test/cupertino/cupertino_popover_menu_test.dart
+++ b/test/cupertino/cupertino_popover_menu_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:golden_toolkit/golden_toolkit.dart';
 import 'package:overlord/overlord.dart';
+import 'package:overlord/src/menus/menu_with_pointer.dart';
 
 void main() {
   group('iOS Toolbar', () {
@@ -98,7 +99,7 @@ void main() {
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 300),
             child: const CupertinoPopoverToolbar(
-              globalFocalPoint: Offset(250, 0),
+              focalPoint: StationaryMenuFocalPoint(Offset(250, 0)),
               children: [
                 CupertinoPopoverToolbarMenuItem(label: 'Style'),
                 CupertinoPopoverToolbarMenuItem(label: 'Duplicate'),
@@ -142,7 +143,7 @@ void main() {
         await _pumpToolbarScaffold(
           tester,
           child: CupertinoPopoverToolbar.paginated(
-            globalFocalPoint: const Offset(250, 0),
+            focalPoint: const StationaryMenuFocalPoint(Offset(250, 0)),
             pages: [
               MenuPage(
                 items: const [
@@ -366,7 +367,7 @@ Future<void> _pumpIosToolbar(
   await _pumpToolbarScaffold(
     tester,
     child: CupertinoPopoverToolbar(
-      globalFocalPoint: arrowFocalPoint,
+      focalPoint: StationaryMenuFocalPoint(arrowFocalPoint),
       children: const [
         CupertinoPopoverToolbarMenuItem(label: 'Style'),
         CupertinoPopoverToolbarMenuItem(label: 'Duplicate'),
@@ -411,7 +412,7 @@ Future<void> _pumpPopoverMenuTestApp(
       home: Scaffold(
         body: Center(
           child: CupertinoPopoverMenu(
-            globalFocalPoint: arrowFocalPoint,
+            focalPoint: StationaryMenuFocalPoint(arrowFocalPoint),
             child: const SizedBox(
               width: 254,
               height: 159,


### PR DESCRIPTION
Menus now follow an object that reports an Offset when requested, instead of always following a static Offset (Resolves #2)

Menus with arrows that follow a `Leader` no longer need to manually track the offset of the `Leader`.