### PR TITLE
Adjusted iOS toolbar height control, and turned demo into a grid (Resolves #4)

### DIFF
--- a/example/lib/demos/demo_toolbar.dart
+++ b/example/lib/demos/demo_toolbar.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print
+
 import 'package:flutter/material.dart';
 import 'package:overlord/overlord.dart';
 
@@ -16,158 +18,484 @@ class ToolbarDemo extends StatefulWidget {
 }
 
 class _ToolbarDemoState extends State<ToolbarDemo> {
-  late List<ToolbarDemoItem> items;
-  late ToolbarDemoItem _selectedItem;
-
-  final smallList = const [
-    CupertinoPopoverToolbarMenuItem(label: 'Style'),
-    CupertinoPopoverToolbarMenuItem(label: 'Duplicate'),
-    CupertinoPopoverToolbarMenuItem(label: 'Cut'),
-    CupertinoPopoverToolbarMenuItem(label: 'Copy'),
-    CupertinoPopoverToolbarMenuItem(label: 'Paste'),
-  ];
-
-  final longList = const [
-    CupertinoPopoverToolbarMenuItem(label: 'Style'),
-    CupertinoPopoverToolbarMenuItem(label: 'Duplicate'),
-    CupertinoPopoverToolbarMenuItem(label: 'Cut'),
-    CupertinoPopoverToolbarMenuItem(label: 'Copy'),
-    CupertinoPopoverToolbarMenuItem(label: 'Paste'),
-    CupertinoPopoverToolbarMenuItem(label: 'Delete'),
-    CupertinoPopoverToolbarMenuItem(label: 'Long Thing 1'),
-    CupertinoPopoverToolbarMenuItem(label: 'Long Thing 2'),
-    CupertinoPopoverToolbarMenuItem(label: 'Long Thing 3'),
-    CupertinoPopoverToolbarMenuItem(label: 'Long Thing 4'),
-    CupertinoPopoverToolbarMenuItem(label: 'Long Thing 5'),
-  ];
+  late final ScrollController _scrollController;
 
   @override
   void initState() {
     super.initState();
+    _scrollController = ScrollController()..addListener(_onScrollChange);
+  }
 
-    items = [
-      ToolbarDemoItem(
-        label: 'Pointing Up',
-        builder: (context) => ToolbarExample(
-          focalPoint: const Offset(600, 0),
-          children: smallList,
-        ),
-      ),
-      ToolbarDemoItem(
-        label: 'Pointing Down',
-        builder: (context) => ToolbarExample(
-          focalPoint: const Offset(600, 1000),
-          children: smallList,
-        ),
-      ),
-      ToolbarDemoItem(
-        label: 'Auto Paginated',
-        builder: (context) => ToolbarExample(
-          focalPoint: const Offset(600, 1000),
-          constraints: const BoxConstraints(maxWidth: 300),
-          children: longList,
-        ),
-      ),
-      ToolbarDemoItem(
-        label: 'Manually Paginated',
-        builder: (context) => ToolbarExample(
-          focalPoint: const Offset(600, 1000),
-          pages: [
-            MenuPage(
-              items: const [
-                CupertinoPopoverToolbarMenuItem(label: 'Style'),
-                CupertinoPopoverToolbarMenuItem(label: 'Duplicate'),
-              ],
-            ),
-            MenuPage(
-              items: const [
-                CupertinoPopoverToolbarMenuItem(label: 'Cut'),
-                CupertinoPopoverToolbarMenuItem(label: 'Copy'),
-                CupertinoPopoverToolbarMenuItem(label: 'Paste'),
-                CupertinoPopoverToolbarMenuItem(label: 'Delete'),
-              ],
-            ),
-            MenuPage(
-              items: const [
-                CupertinoPopoverToolbarMenuItem(label: 'Page 3 Copy'),
-                CupertinoPopoverToolbarMenuItem(label: 'Page 3 Paste'),
-                CupertinoPopoverToolbarMenuItem(label: 'Page 3 Delete'),
-              ],
-            ),
-          ],
-        ),
-      ),
-      ToolbarDemoItem(
-        label: 'Draggable',
-        builder: (context) => DraggableDemo(
-          focalPoint: const Offset(500, 334),
-          children: smallList,
-        ),
-      ),
-    ];
-    _selectedItem = items.first;
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScrollChange() {
+    setState(() {
+      // We rebuild the tree so that each demo rebuilds, and gets an opportunity
+      // to locate its new global offset focal point, due to the scroll movement.
+      //
+      // Rebuilding on every scroll frame is very inefficient and shouldn't be
+      // done in general. If you want a menu to follow a moving focal point, consider
+      // using the follow_the_leader package to follow a moving widget.
+    });
   }
 
   @override
   Widget build(BuildContext context) {
     return SizedBox.expand(
-      child: Row(
-        children: [
-          Expanded(
-            child: _selectedItem.builder(context),
-          ),
-          Container(
-            color: Colors.redAccent,
-            height: double.infinity,
-            width: 250,
-            child: SingleChildScrollView(
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  children: [
-                    const SizedBox(height: 48),
-                    for (final item in items) ...[
-                      _buildDemoButton(item),
-                      const SizedBox(height: 24),
-                    ]
-                  ],
+      child: SingleChildScrollView(
+        controller: _scrollController,
+        child: _buildDemoGrid(),
+      ),
+    );
+  }
+
+  Widget _buildDemoGrid() {
+    final demoRows = <Widget>[];
+    for (int i = 0; i < _demoItems.length; i += 2) {
+      demoRows.add(
+        Row(
+          children: [
+            Expanded(
+              child: _buildDemo(_demoItems[i].builder),
+            ),
+            Expanded(
+              child: (i + 1 < _demoItems.length) //
+                  ? _buildDemo(_demoItems[i + 1].builder) //
+                  : const SizedBox(),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Column(
+      children: demoRows,
+    );
+  }
+
+  Widget _buildDemo(_DemoBuilder demoBuilder) {
+    return AspectRatio(
+      aspectRatio: 1.0,
+      child: Container(
+        width: double.infinity,
+        height: double.infinity,
+        decoration: BoxDecoration(
+          border: Border.all(color: Colors.white.withOpacity(0.1), width: 1),
+        ),
+        child: LayoutBuilder(builder: (context, constraints) {
+          return demoBuilder(context, constraints.loosen());
+        }),
+      ),
+    );
+  }
+}
+
+typedef _DemoBuilder = Widget Function(BuildContext, [BoxConstraints boundConstraints]);
+
+final _demoItems = [
+  _ToolbarDemoItem(
+    label: 'Pointing Up',
+    builder: (context, [BoxConstraints? constraints]) {
+      Offset focalPoint = const Offset(600, 0);
+      if (constraints != null) {
+        final size = constraints.biggest;
+        focalPoint = Alignment.topCenter.alongSize(size);
+      }
+
+      return ToolbarExample(
+        demoTitle: "Pointing Up",
+        focalPoint: focalPoint,
+        constraints: constraints,
+        children: _shortListOfToolbarItems,
+      );
+    },
+  ),
+  _ToolbarDemoItem(
+    label: 'Pointing Down',
+    builder: (context, [BoxConstraints? constraints]) {
+      Offset focalPoint = const Offset(600, 1000);
+      if (constraints != null) {
+        final size = constraints.biggest;
+        focalPoint = Alignment.bottomCenter.alongSize(size);
+      }
+
+      return ToolbarExample(
+        demoTitle: "Pointing Down",
+        focalPoint: focalPoint,
+        constraints: constraints,
+        children: _shortListOfToolbarItems,
+      );
+    },
+  ),
+  _ToolbarDemoItem(
+    label: 'Thin',
+    builder: (context, [BoxConstraints? constraints]) {
+      Offset focalPoint = const Offset(600, 1000);
+      if (constraints != null) {
+        final size = constraints.biggest;
+        focalPoint = Alignment.bottomCenter.alongSize(size);
+      }
+
+      return ToolbarExample(
+        demoTitle: "Thin",
+        focalPoint: focalPoint,
+        constraints: constraints,
+        toolbarHeight: 24,
+        children: _shortListOfToolbarItems,
+      );
+    },
+  ),
+  _ToolbarDemoItem(
+    label: 'Thick',
+    builder: (context, [BoxConstraints? constraints]) {
+      Offset focalPoint = const Offset(600, 1000);
+      if (constraints != null) {
+        final size = constraints.biggest;
+        focalPoint = Alignment.bottomCenter.alongSize(size);
+      }
+
+      return ToolbarExample(
+        demoTitle: "Thick",
+        focalPoint: focalPoint,
+        constraints: constraints,
+        toolbarHeight: 72,
+        children: _shortListOfToolbarItems,
+      );
+    },
+  ),
+  _ToolbarDemoItem(
+    label: 'Auto Paginated',
+    builder: (context, [BoxConstraints? constraints]) {
+      Offset focalPoint = const Offset(600, 1000);
+      if (constraints != null) {
+        final size = constraints.biggest;
+        focalPoint = Alignment.bottomCenter.alongSize(size);
+      }
+
+      return ToolbarExample(
+        demoTitle: "Auto Paginated",
+        focalPoint: focalPoint,
+        constraints: constraints,
+        children: _longListOfToolbarItems,
+      );
+    },
+  ),
+  _ToolbarDemoItem(
+    label: 'Manually Paginated',
+    builder: (context, [BoxConstraints? constraints]) {
+      Offset focalPoint = const Offset(600, 1000);
+      if (constraints != null) {
+        final size = constraints.biggest;
+        focalPoint = Alignment.bottomCenter.alongSize(size);
+      }
+
+      return ToolbarExample(
+        demoTitle: "Manually Paginated",
+        focalPoint: focalPoint,
+        constraints: constraints,
+        pages: _pagedToolbarItems,
+      );
+    },
+  ),
+  _ToolbarDemoItem(
+    label: 'Draggable',
+    builder: (context, [BoxConstraints? constraints]) {
+      Offset focalPoint = const Offset(600, 1000);
+      if (constraints != null) {
+        final size = constraints.biggest;
+        focalPoint = Alignment.center.alongSize(size);
+      }
+
+      return _DraggableDemo(
+        focalPoint: focalPoint,
+        children: _shortListOfToolbarItems,
+      );
+    },
+  ),
+];
+
+final _shortListOfToolbarItems = [
+  CupertinoPopoverToolbarMenuItem(
+    label: 'Style',
+    onPressed: () {
+      print("Pressed 'Style'");
+    },
+  ),
+  CupertinoPopoverToolbarMenuItem(
+    label: 'Duplicate',
+    onPressed: () {
+      print("Pressed 'Duplicate'");
+    },
+  ),
+  CupertinoPopoverToolbarMenuItem(
+    label: 'Cut',
+    onPressed: () {
+      print("Pressed 'Cut'");
+    },
+  ),
+  CupertinoPopoverToolbarMenuItem(
+    label: 'Copy',
+    onPressed: () {
+      print("Pressed 'Copy'");
+    },
+  ),
+  CupertinoPopoverToolbarMenuItem(
+    label: 'Paste',
+    onPressed: () {
+      print("Pressed 'Paste'");
+    },
+  ),
+];
+
+final _longListOfToolbarItems = [
+  CupertinoPopoverToolbarMenuItem(
+    label: 'Style',
+    onPressed: () {
+      print("Pressed 'Style'");
+    },
+  ),
+  CupertinoPopoverToolbarMenuItem(
+    label: 'Duplicate',
+    onPressed: () {
+      print("Pressed 'Duplicate'");
+    },
+  ),
+  CupertinoPopoverToolbarMenuItem(
+    label: 'Cut',
+    onPressed: () {
+      print("Pressed 'Cut'");
+    },
+  ),
+  CupertinoPopoverToolbarMenuItem(
+    label: 'Copy',
+    onPressed: () {
+      print("Pressed 'Copy'");
+    },
+  ),
+  CupertinoPopoverToolbarMenuItem(
+    label: 'Paste',
+    onPressed: () {
+      print("Pressed 'Paste'");
+    },
+  ),
+  CupertinoPopoverToolbarMenuItem(
+    label: 'Delete',
+    onPressed: () {
+      print("Pressed 'Delete'");
+    },
+  ),
+  CupertinoPopoverToolbarMenuItem(
+    label: 'Long Thing 1',
+    onPressed: () {
+      print("Pressed 'Long Thing 1'");
+    },
+  ),
+  CupertinoPopoverToolbarMenuItem(
+    label: 'Long Thing 2',
+    onPressed: () {
+      print("Pressed 'Long Thing 2'");
+    },
+  ),
+  CupertinoPopoverToolbarMenuItem(
+    label: 'Long Thing 3',
+    onPressed: () {
+      print("Pressed 'Long Thing 3'");
+    },
+  ),
+  CupertinoPopoverToolbarMenuItem(
+    label: 'Long Thing 4',
+    onPressed: () {
+      print("Pressed 'Long Thing 4'");
+    },
+  ),
+  CupertinoPopoverToolbarMenuItem(
+    label: 'Long Thing 5',
+    onPressed: () {
+      print("Pressed 'Long Thing 5'");
+    },
+  ),
+];
+
+final _pagedToolbarItems = [
+  MenuPage(
+    items: [
+      CupertinoPopoverToolbarMenuItem(
+        label: 'Style',
+        onPressed: () {
+          print("Pressed 'Style'");
+        },
+      ),
+      CupertinoPopoverToolbarMenuItem(
+        label: 'Duplicate',
+        onPressed: () {
+          print("Pressed 'Duplicate'");
+        },
+      ),
+    ],
+  ),
+  MenuPage(
+    items: [
+      CupertinoPopoverToolbarMenuItem(
+        label: 'Cut',
+        onPressed: () {
+          print("Pressed 'Cut'");
+        },
+      ),
+      CupertinoPopoverToolbarMenuItem(
+        label: 'Copy',
+        onPressed: () {
+          print("Pressed 'Copy'");
+        },
+      ),
+      CupertinoPopoverToolbarMenuItem(
+        label: 'Paste',
+        onPressed: () {
+          print("Pressed 'Paste'");
+        },
+      ),
+      CupertinoPopoverToolbarMenuItem(
+        label: 'Delete',
+        onPressed: () {
+          print("Pressed 'Delete'");
+        },
+      ),
+    ],
+  ),
+  MenuPage(
+    items: [
+      CupertinoPopoverToolbarMenuItem(
+        label: 'Page 3 Copy',
+        onPressed: () {
+          print("Pressed 'Page 3 Copy'");
+        },
+      ),
+      CupertinoPopoverToolbarMenuItem(
+        label: 'Page 3 Paste',
+        onPressed: () {
+          print("Pressed 'Page 3 Paste'");
+        },
+      ),
+      CupertinoPopoverToolbarMenuItem(
+        label: 'Page 3 Delete',
+        onPressed: () {
+          print("Pressed 'Page 3 Delete'");
+        },
+      ),
+    ],
+  ),
+];
+
+class _ToolbarDemoItem {
+  _ToolbarDemoItem({
+    required this.label,
+    required this.builder,
+  });
+
+  final String label;
+  final _DemoBuilder builder;
+}
+
+/// An example of an [IosToolbar] usage.
+///
+/// When [constraints] are provided, the toolbar is displayed inside a [ConstrainedBox].
+///
+/// Use [pages] to manually configure the menu pages.
+///
+/// Use [children] to let the toolbar compute the pages based on the available width.
+class ToolbarExample extends StatefulWidget {
+  const ToolbarExample({
+    super.key,
+    required this.demoTitle,
+    required this.focalPoint,
+    this.constraints,
+    this.pages,
+    this.toolbarHeight,
+    this.children,
+  })  : assert(children != null || pages != null, 'You should provide either children or pages'),
+        assert(children == null || pages == null, "You can't provide both children and pages");
+
+  final String demoTitle;
+  final BoxConstraints? constraints;
+  final List<MenuPage>? pages;
+  final Offset focalPoint;
+  final double? toolbarHeight;
+  final List<Widget>? children;
+
+  @override
+  State<ToolbarExample> createState() => _ToolbarExampleState();
+}
+
+class _ToolbarExampleState extends State<ToolbarExample> {
+  @override
+  Widget build(BuildContext context) {
+    // Re-calculate focal point on every frame, because the toolbar expects a
+    // global value, and these demos can scroll up and down, so it changes.
+    Offset globalFocalPoint = widget.focalPoint;
+    final myBox = context.findRenderObject() as RenderBox?;
+    if (myBox != null) {
+      globalFocalPoint = myBox.localToGlobal(Offset.zero) + widget.focalPoint;
+    } else {
+      // Schedule another frame so that we start with the correct global
+      // focal point.
+      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+        setState(() {});
+      });
+    }
+
+    final toolbar = widget.children != null
+        ? CupertinoPopoverToolbar(
+            focalPoint: StationaryMenuFocalPoint(globalFocalPoint),
+            height: widget.toolbarHeight,
+            children: widget.children!,
+          )
+        : CupertinoPopoverToolbar.paginated(
+            focalPoint: StationaryMenuFocalPoint(globalFocalPoint),
+            height: widget.toolbarHeight,
+            pages: widget.pages,
+          );
+
+    final constrainedToolbar = widget.constraints != null
+        ? ConstrainedBox(
+            constraints: widget.constraints!,
+            child: toolbar,
+          )
+        : toolbar;
+
+    return Stack(
+      children: [
+        Align(
+          alignment: const Alignment(0.0, 0.9),
+          child: Container(
+            height: 24,
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            decoration: BoxDecoration(
+              color: Colors.red,
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: IntrinsicWidth(
+              child: Center(
+                child: Text(
+                  widget.demoTitle,
+                  style: const TextStyle(color: Colors.white, fontSize: 12),
                 ),
               ),
             ),
           ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildDemoButton(ToolbarDemoItem item) {
-    return SizedBox(
-      width: double.infinity,
-      child: ElevatedButton(
-        onPressed: () {
-          setState(() {
-            _selectedItem = item;
-          });
-        },
-        style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
-        child: Text(item.label),
-      ),
+        ),
+        Center(
+          child: constrainedToolbar,
+        ),
+      ],
     );
   }
 }
 
-class ToolbarDemoItem {
-  final String label;
-  final WidgetBuilder builder;
-
-  ToolbarDemoItem({
-    required this.label,
-    required this.builder,
-  });
-}
-
-class DraggableDemo extends StatefulWidget {
-  const DraggableDemo({
+class _DraggableDemo extends StatefulWidget {
+  const _DraggableDemo({
     super.key,
     required this.focalPoint,
     required this.children,
@@ -177,10 +505,10 @@ class DraggableDemo extends StatefulWidget {
   final List<Widget> children;
 
   @override
-  State<DraggableDemo> createState() => _DraggableDemoState();
+  State<_DraggableDemo> createState() => _DraggableDemoState();
 }
 
-class _DraggableDemoState extends State<DraggableDemo> {
+class _DraggableDemoState extends State<_DraggableDemo> {
   Offset _offset = const Offset(50, 50);
 
   void _onPanUpdate(DragUpdateDetails details) {
@@ -191,6 +519,20 @@ class _DraggableDemoState extends State<DraggableDemo> {
 
   @override
   Widget build(BuildContext context) {
+    // Re-calculate focal point on every frame, because the toolbar expects a
+    // global value, and these demos can scroll up and down, so it changes.
+    Offset globalFocalPoint = widget.focalPoint;
+    final myBox = context.findRenderObject() as RenderBox?;
+    if (myBox != null) {
+      globalFocalPoint = myBox.localToGlobal(Offset.zero) + widget.focalPoint;
+    } else {
+      // Schedule another frame so that we start with the correct global
+      // focal point.
+      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+        setState(() {});
+      });
+    }
+
     return Stack(
       children: [
         Positioned(
@@ -208,63 +550,12 @@ class _DraggableDemoState extends State<DraggableDemo> {
           child: GestureDetector(
             onPanUpdate: _onPanUpdate,
             child: CupertinoPopoverToolbar(
-              focalPoint: StationaryMenuFocalPoint(widget.focalPoint),
-              padding: const EdgeInsets.all(12.0),
-              arrowBaseWidth: 21,
-              arrowLength: 20,
-              backgroundColor: const Color(0xFF474747),
+              focalPoint: StationaryMenuFocalPoint(globalFocalPoint),
               children: widget.children,
             ),
           ),
         ),
       ],
-    );
-  }
-}
-
-/// An example of an [IosToolbar] usage.
-///
-/// When [constraints] are provided, the toolbar is displayed inside a [ConstrainedBox].
-///
-/// Use [pages] to manually configure the menu pages.
-///
-/// Use [children] to let the toolbar compute the pages based on the available width.
-class ToolbarExample extends StatelessWidget {
-  const ToolbarExample({
-    super.key,
-    required this.focalPoint,
-    this.constraints,
-    this.pages,
-    this.children,
-  })  : assert(children != null || pages != null, 'You should provide either children or pages'),
-        assert(children == null || pages == null, "You can't provide both children and pages");
-
-  final BoxConstraints? constraints;
-  final List<MenuPage>? pages;
-  final Offset focalPoint;
-  final List<Widget>? children;
-
-  @override
-  Widget build(BuildContext context) {
-    final toolbar = children != null
-        ? CupertinoPopoverToolbar(
-            focalPoint: StationaryMenuFocalPoint(focalPoint),
-            children: children!,
-          )
-        : CupertinoPopoverToolbar.paginated(
-            focalPoint: StationaryMenuFocalPoint(focalPoint),
-            pages: pages,
-          );
-
-    final result = constraints != null
-        ? ConstrainedBox(
-            constraints: constraints!,
-            child: toolbar,
-          )
-        : toolbar;
-
-    return Center(
-      child: result,
     );
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,42 +5,48 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   flutter:
@@ -52,7 +58,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   flutter_test:
@@ -69,39 +76,52 @@ packages:
       url: "git@github.com:Flutter-Bounty-Hunters/follow_the_leader.git"
     source: git
     version: "0.0.3"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.5"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: c0bbfe94d46aedf9b8b3e695cf3bd48c8e14b35e3b2c639e0aa7755d589ba946
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   overlord:
@@ -110,12 +130,13 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.2"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
   sky_engine:
@@ -127,51 +148,58 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "862015c5db1f3f3c4ea3b94dc2490363a84262994b88902315ed74be1155612f"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: c9aba3b3dbfe8878845dfab5fa096eb8de7b62231baeeb1cea8e3ee81ca8c6d8
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.15"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=2.18.0 <4.0.0"
   flutter: ">=1.17.0"

--- a/lib/src/cupertino/cupertino_popover_menu.dart
+++ b/lib/src/cupertino/cupertino_popover_menu.dart
@@ -224,7 +224,6 @@ class RenderPopover extends RenderShiftedBox {
   @override
   void paint(PaintingContext context, Offset offset) {
     final localFocalPoint = globalToLocal(focalPoint.globalOffset!);
-    print("Menu focal point: ${focalPoint.globalOffset!}");
 
     final contentOffset = _computeContentOffset(arrowLength);
     final direction = _computeArrowDirection(Offset.zero & size, localFocalPoint);

--- a/lib/src/cupertino/cupertino_toolbar.dart
+++ b/lib/src/cupertino/cupertino_toolbar.dart
@@ -21,12 +21,13 @@ class CupertinoPopoverToolbar extends StatefulWidget {
     required this.focalPoint,
     this.arrowBaseWidth = 18.0,
     this.arrowLength = 12.0,
-    this.height = 39.0,
+    double? height,
     this.borderRadius = 12.0,
     this.padding,
     this.backgroundColor = const Color(0xFF333333),
     required this.children,
   })  : pages = null,
+        height = height ?? 39.0,
         super(key: key);
 
   /// Creates a toolbar which is paginated using [pages].
@@ -35,12 +36,13 @@ class CupertinoPopoverToolbar extends StatefulWidget {
     required this.focalPoint,
     this.arrowBaseWidth = 18.0,
     this.arrowLength = 12.0,
-    this.height = 39.0,
+    double? height,
     this.borderRadius = 12.0,
     this.padding,
     this.backgroundColor = const Color(0xFF333333),
     required this.pages,
-  }) : children = null;
+  })  : height = height ?? 39.0,
+        children = null;
 
   /// Where the toolbar's arrow should point.
   ///
@@ -116,8 +118,8 @@ class _CupertinoPopoverToolbarState extends State<CupertinoPopoverToolbar> {
     return AnimatedBuilder(
       animation: _controller,
       builder: (context, child) {
-        return ConstrainedBox(
-          constraints: const BoxConstraints(minHeight: 39, maxHeight: 39),
+        return SizedBox(
+          height: widget.height,
           child: _IosToolbarMenuContent(
             controller: _controller,
             height: widget.height,


### PR DESCRIPTION
Adjusted iOS toolbar height control, and turned demo into a grid (Resolves #4)

This PR adjusts the application of height to the toolbar. For some reason, we previously had `BoxConstraints` with an identical min and max height. So I replaced that with a `SizedBox` and a single `height`.


https://user-images.githubusercontent.com/7259036/208564619-f1697eac-3b39-4abc-b38e-d2a63d985cf6.mov

