### PR TITLE
Add elevation to iOS popover

### DIFF
--- a/lib/src/cupertino/cupertino_popover_menu.dart
+++ b/lib/src/cupertino/cupertino_popover_menu.dart
@@ -20,8 +20,10 @@ class CupertinoPopoverMenu extends SingleChildRenderObjectWidget {
     this.backgroundColor = const Color(0xFF474747),
     this.padding,
     this.showDebugPaint = false,
+    this.elevation = 0.0,
+    this.shadowColor = const Color(0xFF000000),
     super.child,
-  });
+  }) : assert(elevation >= 0.0);
 
   /// Where the toolbar arrow should point.
   final MenuFocalPoint focalPoint;
@@ -54,6 +56,14 @@ class CupertinoPopoverMenu extends SingleChildRenderObjectWidget {
   /// Color of the menu background.
   final Color backgroundColor;
 
+  /// The z-coordinate relative to the parent at which to place this popover.
+  ///
+  /// The value is non-negative.
+  final double elevation;
+
+  /// The shadow color.
+  final Color shadowColor;
+
   /// Whether to add decorations that show useful metrics for this popover's
   /// layout and position.
   final bool showDebugPaint;
@@ -67,6 +77,8 @@ class CupertinoPopoverMenu extends SingleChildRenderObjectWidget {
       padding: padding,
       screenSize: MediaQuery.of(context).size,
       backgroundColor: backgroundColor,
+      elevation: elevation,
+      shadowColor: shadowColor,
       focalPoint: focalPoint,
       allowHorizontalArrow: allowHorizontalArrow,
       showDebugPaint: showDebugPaint,
@@ -84,6 +96,8 @@ class CupertinoPopoverMenu extends SingleChildRenderObjectWidget {
       ..screenSize = MediaQuery.of(context).size
       ..focalPoint = focalPoint
       ..backgroundColor = backgroundColor
+      ..elevation = elevation
+      ..shadowColor = shadowColor
       ..allowHorizontalArrow = allowHorizontalArrow
       ..showDebugPaint = showDebugPaint;
   }
@@ -95,6 +109,8 @@ class RenderPopover extends RenderShiftedBox {
     required double arrowWidth,
     required double arrowLength,
     required Color backgroundColor,
+    required double elevation,
+    required Color shadowColor,
     required MenuFocalPoint focalPoint,
     required Size screenSize,
     bool allowHorizontalArrow = true,
@@ -107,6 +123,8 @@ class RenderPopover extends RenderShiftedBox {
         _padding = padding,
         _screenSize = screenSize,
         _backgroundColor = backgroundColor,
+        _elevation = elevation,
+        _shadowColor = shadowColor,
         _backgroundPaint = Paint()..color = backgroundColor,
         _focalPoint = focalPoint,
         _allowHorizontalArrow = allowHorizontalArrow,
@@ -173,6 +191,24 @@ class RenderPopover extends RenderShiftedBox {
     if (value != _backgroundColor) {
       _backgroundColor = value;
       _backgroundPaint = Paint()..color = _backgroundColor;
+      markNeedsPaint();
+    }
+  }
+
+  double _elevation;
+  double get elevation => _elevation;
+  set elevation(double value) {
+    if (value != _elevation) {
+      _elevation = value;
+      markNeedsPaint();
+    }
+  }
+
+  Color _shadowColor;
+  Color get shadowColor => _shadowColor;
+  set shadowColor(Color value) {
+    if (value != _shadowColor) {
+      _shadowColor = value;
       markNeedsPaint();
     }
   }
@@ -247,6 +283,15 @@ class RenderPopover extends RenderShiftedBox {
     }
 
     final borderPath = _buildBorderPath(direction, arrowCenter);
+
+    if (elevation != 0.0) {
+      context.canvas.drawShadow(
+        borderPath,
+        _shadowColor,
+        _elevation,
+        _backgroundColor.alpha != 0xFF,
+      );
+    }
 
     context.canvas.drawPath(borderPath.shift(offset), _backgroundPaint);
 

--- a/lib/src/cupertino/cupertino_popover_menu.dart
+++ b/lib/src/cupertino/cupertino_popover_menu.dart
@@ -56,16 +56,16 @@ class CupertinoPopoverMenu extends SingleChildRenderObjectWidget {
   /// Color of the menu background.
   final Color backgroundColor;
 
-  /// The z-coordinate relative to the parent at which to place this popover.
+  /// The virtual distance between this menu and the content that sits beneath it, which determines
+  /// the size, opacity, and spread of the menu's shadow.
   ///
-  /// This controls the size of the shadow below the toolbar and the opacity.
-  ///
-  /// The value is non-negative.
+  /// The value must be non-negative.
   final double elevation;
 
-  /// The shadow color.
+  /// The color of the shadow cast by this menu.
   ///
-  /// The opacity is controlled by the [elevation].
+  /// The opacity of [shadowColor] is ignored. Instead, the final opacity of the shadow
+  /// is determined by [elevation].
   final Color shadowColor;
 
   /// Whether to add decorations that show useful metrics for this popover's
@@ -289,11 +289,12 @@ class RenderPopover extends RenderShiftedBox {
     final borderPath = _buildBorderPath(direction, arrowCenter);
 
     if (elevation != 0.0) {
+      final isMenuTranslucent = _backgroundColor.alpha != 0xFF;
       context.canvas.drawShadow(
         borderPath,
         _shadowColor,
         _elevation,
-        _backgroundColor.alpha != 0xFF,
+        isMenuTranslucent,
       );
     }
 

--- a/lib/src/cupertino/cupertino_popover_menu.dart
+++ b/lib/src/cupertino/cupertino_popover_menu.dart
@@ -58,10 +58,14 @@ class CupertinoPopoverMenu extends SingleChildRenderObjectWidget {
 
   /// The z-coordinate relative to the parent at which to place this popover.
   ///
+  /// This controls the size of the shadow below the toolbar and the opacity.
+  ///
   /// The value is non-negative.
   final double elevation;
 
   /// The shadow color.
+  ///
+  /// The opacity is controlled by the [elevation].
   final Color shadowColor;
 
   /// Whether to add decorations that show useful metrics for this popover's

--- a/lib/src/cupertino/cupertino_toolbar.dart
+++ b/lib/src/cupertino/cupertino_toolbar.dart
@@ -28,7 +28,8 @@ class CupertinoPopoverToolbar extends StatefulWidget {
     this.elevation = 0.0,
     this.shadowColor = const Color(0xFF000000),
     required this.children,
-  })  : pages = null,
+  })  : assert(elevation >= 0.0),
+        pages = null,
         height = height ?? 39.0,
         super(key: key);
 
@@ -85,10 +86,14 @@ class CupertinoPopoverToolbar extends StatefulWidget {
 
   /// The z-coordinate relative to the parent at which to place this toolbar.
   ///
+  /// This controls the size of the shadow below the toolbar and the opacity.
+  ///
   /// The value is non-negative.
   final double elevation;
 
   /// The shadow color.
+  ///
+  /// The opacity is controlled by the [elevation].
   final Color shadowColor;
 
   /// Pages of menu items.

--- a/lib/src/cupertino/cupertino_toolbar.dart
+++ b/lib/src/cupertino/cupertino_toolbar.dart
@@ -84,16 +84,16 @@ class CupertinoPopoverToolbar extends StatefulWidget {
   /// All of the items will have this exact height.
   final double height;
 
-  /// The z-coordinate relative to the parent at which to place this toolbar.
+  /// The virtual distance between this toolbar and the content that sits beneath it, which determines
+  /// the size, opacity, and spread of the toolbar's shadow.
   ///
-  /// This controls the size of the shadow below the toolbar and the opacity.
-  ///
-  /// The value is non-negative.
+  /// The value must be non-negative.
   final double elevation;
 
-  /// The shadow color.
+  /// The color of the shadow cast by this toolbar.
   ///
-  /// The opacity is controlled by the [elevation].
+  /// The opacity of [shadowColor] is ignored. Instead, the final opacity of the shadow
+  /// is determined by [elevation].
   final Color shadowColor;
 
   /// Pages of menu items.

--- a/lib/src/cupertino/cupertino_toolbar.dart
+++ b/lib/src/cupertino/cupertino_toolbar.dart
@@ -25,6 +25,8 @@ class CupertinoPopoverToolbar extends StatefulWidget {
     this.borderRadius = 12.0,
     this.padding,
     this.backgroundColor = const Color(0xFF333333),
+    this.elevation = 0.0,
+    this.shadowColor = const Color(0xFF000000),
     required this.children,
   })  : pages = null,
         height = height ?? 39.0,
@@ -40,6 +42,8 @@ class CupertinoPopoverToolbar extends StatefulWidget {
     this.borderRadius = 12.0,
     this.padding,
     this.backgroundColor = const Color(0xFF333333),
+    this.elevation = 0.0,
+    this.shadowColor = const Color(0xFF000000),
     required this.pages,
   })  : height = height ?? 39.0,
         children = null;
@@ -79,6 +83,14 @@ class CupertinoPopoverToolbar extends StatefulWidget {
   /// All of the items will have this exact height.
   final double height;
 
+  /// The z-coordinate relative to the parent at which to place this toolbar.
+  ///
+  /// The value is non-negative.
+  final double elevation;
+
+  /// The shadow color.
+  final Color shadowColor;
+
   /// Pages of menu items.
   ///
   /// Can't be provided if [children] are provided.
@@ -107,6 +119,8 @@ class _CupertinoPopoverToolbarState extends State<CupertinoPopoverToolbar> {
       arrowBaseWidth: widget.arrowBaseWidth,
       arrowLength: widget.arrowLength,
       backgroundColor: widget.backgroundColor,
+      elevation: widget.elevation,
+      shadowColor: widget.shadowColor,
       focalPoint: widget.focalPoint,
       allowHorizontalArrow: false,
       padding: widget.padding,


### PR DESCRIPTION
To be able to implement light themes, we need to add elevation to the iOS toolbar.

This PR adds the ability to specify the `elevation` and the `shadowColor` on both `CupertinoPopoverMenu` and `CupertinoPopoverToolbar`.

Without elevation:

![without_elevation](https://user-images.githubusercontent.com/7597082/214985226-15eae69d-118b-4ba4-ba84-6aa948250d8e.png)

With elevation:

![with_elevation](https://user-images.githubusercontent.com/7597082/214985374-015480f8-e6e3-4be6-b678-07875703dd58.png)
