### PR TITLE
Allow customizing the follower vertical offset in CupertinoPopoverToolbarAligner.

### DIFF
--- a/lib/src/cupertino/cupertino_popover_aligners.dart
+++ b/lib/src/cupertino/cupertino_popover_aligners.dart
@@ -7,7 +7,18 @@ import 'package:overlord/overlord.dart';
 /// Use with `Follower.withDynamics` to position the toolbar based on
 /// proximity to the bounds of the screen.
 class CupertinoPopoverToolbarAligner implements FollowerAligner {
-  CupertinoPopoverToolbarAligner();
+  CupertinoPopoverToolbarAligner({
+    this.toolbarVerticalOffsetAbove = 20,
+    this.toolbarVerticalOffsetBelow = 20,
+  });
+
+  /// The vertical offset to apply between the toolbar and the leader
+  /// when the toolbar is positioned above the leader.
+  final double toolbarVerticalOffsetAbove;
+
+  /// The vertical offset to apply between the toolbar and the leader
+  /// when the toolbar is positioned below the leader.
+  final double toolbarVerticalOffsetBelow;
 
   @override
   FollowerAlignment align(Rect globalLeaderRect, Size followerSize, [Rect? globalBounds]) {
@@ -17,18 +28,18 @@ class CupertinoPopoverToolbarAligner implements FollowerAligner {
     if (globalLeaderRect.top - followerSize.height - _popoverToolbarMinimumDistanceFromEdge < bounds.top) {
       OverlordLogs.cupertinoToolbar.fine(" - follower is too far to the top, switching to bottom");
       // The follower hit the minimum distance. Invert the follower position.
-      alignment = const FollowerAlignment(
+      alignment = FollowerAlignment(
         leaderAnchor: Alignment.bottomCenter,
         followerAnchor: Alignment.topCenter,
-        followerOffset: Offset(0, 20),
+        followerOffset: Offset(0, toolbarVerticalOffsetBelow),
       );
     } else {
       // There's enough room to display toolbar above content. That's our desired
       // default position, so put the toolbar on top.
-      alignment = const FollowerAlignment(
+      alignment = FollowerAlignment(
         leaderAnchor: Alignment.topCenter,
         followerAnchor: Alignment.bottomCenter,
-        followerOffset: Offset(0, -20),
+        followerOffset: Offset(0, -toolbarVerticalOffsetAbove),
       );
     }
 

--- a/lib/src/cupertino/cupertino_popover_menu.dart
+++ b/lib/src/cupertino/cupertino_popover_menu.dart
@@ -453,7 +453,7 @@ class RenderPopover extends RenderShiftedBox {
   void applyPaintTransform(RenderObject child, Matrix4 transform) {
     // Applying our padding offset to the paint transform lets Flutter's
     // "Debug Paint" show the correct child widget bounds.
-    return transform.translate(_contentOffset.dx, _contentOffset.dy);
+    return transform.translateByDouble(_contentOffset.dx, _contentOffset.dy, 0, 0);
   }
 
   @override

--- a/lib/src/cupertino/cupertino_popover_menu.dart
+++ b/lib/src/cupertino/cupertino_popover_menu.dart
@@ -453,7 +453,7 @@ class RenderPopover extends RenderShiftedBox {
   void applyPaintTransform(RenderObject child, Matrix4 transform) {
     // Applying our padding offset to the paint transform lets Flutter's
     // "Debug Paint" show the correct child widget bounds.
-    return transform.translateByDouble(_contentOffset.dx, _contentOffset.dy, 0, 0);
+    return transform.translateByDouble(_contentOffset.dx, _contentOffset.dy, 0, 1.0);
   }
 
   @override


### PR DESCRIPTION
Allow customizing the follower vertical offset in CupertinoPopoverToolbarAligner.

Currently, the gap between the leader and the toolbar is hardcoded as 20px. To be able to implement the new Android text editing toolbar we need a bigger gap.

This PR adds the ability of customizing the gap.